### PR TITLE
feat: add lyrics focus button

### DIFF
--- a/app/components/LyricsTrack.vue
+++ b/app/components/LyricsTrack.vue
@@ -163,7 +163,7 @@ onMounted(() => {
     <div lt-lg="absolute" pointer-events-auto sticky left-3 right-3 top-3 z-floating flex>
       <div
         v-if="activeLineEl && !targetIsVisible"
-        fixed bottom-8 right-8 floating-glass
+        fixed bottom-3 right-3 floating-glass
         flex="~ gap-2 items-center"
         @click="() => scrollToActiveLine('smooth')"
       >


### PR DESCRIPTION
Related: #3

- 當前 active lyrics line scroll 超出 screen 將會在右下角顯示 auto scroll to line button
- 修正了一些歌詞 line auto scroll 的 logic，支援 player seeking 時自動 scroll 的 ux