### PR TITLE
feat: add `/share` route path for `isPlayer` in `SettingsNav`

### DIFF
--- a/app/components/SettingsNav.vue
+++ b/app/components/SettingsNav.vue
@@ -9,7 +9,7 @@ const route = useRoute()
 const bp = useBreakpoints(breakpointsTailwind)
 const ltMd = bp.isSmaller('md')
 
-const isPlayer = computed(() => route.path.startsWith('/songs') || route.path.startsWith('/demo'))
+const isPlayer = computed(() => route.path.startsWith('/songs') || route.path.startsWith('/demo') || route.path.startsWith('/share'))
 </script>
 
 <template>


### PR DESCRIPTION
- fix `/share` page cannot show setting nav