### PR TITLE
fix: use `bunny` for web fonts, increase timeout

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -52,8 +52,11 @@ export default defineConfig({
     }),
     presetTypography(),
     presetWebFonts({
-      inlineImports: false,
-      provider: 'google',
+      provider: 'bunny',
+      timeouts: {
+        warning: 7_000,
+        failure: 10_000,
+      },
       fonts: {
         'sans': 'DM Sans',
         'serif': 'DM Serif Display',


### PR DESCRIPTION
I think it will be fine if in the dev mode,
just resolve google font and jump out the fetch data issue,
<img width="898" alt="image" src="https://github.com/user-attachments/assets/55435204-2dfa-455f-83f1-6607373e092a">
and in the prod mode we will build out the /asset font file

what do u think,or this will cause any issue?

<img width="892" alt="image" src="https://github.com/user-attachments/assets/6a2d51a7-499d-455e-a185-f99788cc4c78">
