### PR TITLE
 fix: Avoid draggable window staying outside #41 

### DIFF
--- a/app/components/DraggableWindow.vue
+++ b/app/components/DraggableWindow.vue
@@ -42,8 +42,8 @@ function limitPosition() {
 }
 
 onMounted(() => {
-  const limitPositionDebounced = useDebounceFn(() => limitPosition(), 250)
-  useEventListener('resize', () => limitPositionDebounced(), { passive: true })
+  const limitPositionDebounced = useDebounceFn(limitPosition, 250)
+  useEventListener('resize', limitPositionDebounced, { passive: true })
 })
 // #endregion
 </script>


### PR DESCRIPTION
1. Move the draggable window back into the browser window when dragging end
2. On browser window resizing, keep the draggable window stay inside

For (2), do you think it should be only executed on the end of resize or should use a debounce behavior?