### PR TITLE
fix: resolve `auto-pause` getting stuck on first lyric

### DIFF
--- a/app/composables/player.ts
+++ b/app/composables/player.ts
@@ -155,7 +155,7 @@ export function usePlayer(data: MaruSongDataParsed, autoplay = true) {
       current.value = active.value.end
       player.value.seekTo(current.value)
       player.value.pauseVideo()
-      pausedAt = active.value.index
+      pausedAt = active.value.index + 1
     }
     else {
       if (status.value === 'playing') {


### PR DESCRIPTION
When `auto-pause` is enabled, after the lyrics reach the end of the first line and trigger a pause, clicking the play button again will directly pause and not play.

before:

https://github.com/user-attachments/assets/788fbaf6-b1a2-4ffe-af99-ac5b01cdb7aa

after:

https://github.com/user-attachments/assets/68b595e8-b5c0-46b2-b8fa-70be47ac1580