### PR TITLE
feat: add copy success notification

### DIFF
--- a/app/components/Notification.vue
+++ b/app/components/Notification.vue
@@ -1,0 +1,25 @@
+<script setup lang='ts'>
+withDefaults(
+  defineProps<{ value?: boolean }>(),
+  { value: false },
+)
+</script>
+
+<template>
+  <div
+    class="fixed top-0 left-0 right-0 z-50 text-center"
+    :class="value ? '' : 'pointer-events-none overflow-hidden'"
+  >
+    <div
+      class="
+        px-3 py-1 rounded inline-block m-3 transition-all duration-300 text-primary
+        bg-base border border-base
+        flex flex-inline items-center
+      "
+      :style="value ? {} : { transform: 'translateY(-150%)' }"
+      :class="value ? 'shadow' : 'shadow-none'"
+    >
+      <slot />
+    </div>
+  </div>
+</template>

--- a/app/components/Notification.vue
+++ b/app/components/Notification.vue
@@ -7,15 +7,11 @@ withDefaults(
 
 <template>
   <div
-    class="fixed top-0 left-0 right-0 z-50 text-center"
+    class="fixed left-0 right-0 top-0 z-50 text-center"
     :class="value ? '' : 'pointer-events-none overflow-hidden'"
   >
     <div
-      class="
-        px-3 py-1 rounded inline-block m-3 transition-all duration-300 text-primary
-        bg-base border border-base
-        flex flex-inline items-center
-      "
+      class="m-3 inline-block flex flex-inline items-center border border-base rounded px-3 py-1 text-primary transition-all duration-300 bg-base"
       :style="value ? {} : { transform: 'translateY(-150%)' }"
       :class="value ? 'shadow' : 'shadow-none'"
     >

--- a/app/components/SongActions.vue
+++ b/app/components/SongActions.vue
@@ -43,8 +43,14 @@ const shareUrl = computed(() => {
   }
 })
 
-function copyShareLink() {
-  navigator.clipboard.writeText(shareUrl.value)
+const shareStatus = ref(false)
+async function copyShareLink() {
+  await navigator.clipboard.writeText(shareUrl.value)
+
+  shareStatus.value = true
+  setTimeout(() => {
+    shareStatus.value = false
+  }, 2000)
 }
 
 async function exportCurrent() {
@@ -153,4 +159,8 @@ function shareWithQifi() {
       @done="showShareQifiCode = false"
     />
   </ModalPopup>
+  <Notification :value="shareStatus">
+    <span i-uil-check class="font-xl mr-2 inline-block align-middle" />
+    <span class="align-middle">Copied</span>
+  </Notification>
 </template>


### PR DESCRIPTION
This PR adds a notification that pops up when copying is successful. I noticed there was no feedback when a copy action completed.

So I moved the notification feature from `icones` into this project.

https://github.com/user-attachments/assets/e0437b23-3f48-44ae-83e8-85f593a58af5

