### PR TITLE
chore: switching full screen components' height unit from vh to %

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -1,7 +1,7 @@
 html,
 body,
 #__nuxt {
-  height: 100vh;
+  height: 100%;
   margin: 0;
   padding: 0;
 }

--- a/app/app.css
+++ b/app/app.css
@@ -1,6 +1,8 @@
 html,
 body,
 #__nuxt {
+  height: 100%;
+  height: 100vh;
   height: 100dvh;
   margin: 0;
   padding: 0;

--- a/app/app.css
+++ b/app/app.css
@@ -1,7 +1,7 @@
 html,
 body,
 #__nuxt {
-  height: 100%;
+  height: 100dvh;
   margin: 0;
   padding: 0;
 }

--- a/app/components/ImportDialog.vue
+++ b/app/components/ImportDialog.vue
@@ -20,7 +20,7 @@ function onClickOutside() {
 <template>
   <ModalPopup
     :model-value="state.isImporting"
-    dialog-class="max-h-80%! min-h-50% grid grid-rows-[max-content_1fr_max-content] p0!"
+    dialog-class="max-h-80dvh! min-h-50dvh grid grid-rows-[max-content_1fr_max-content] p0!"
     @click-outside="onClickOutside"
   >
     <div p2 text-xl flex="~ gap-2 items-center justify-center" border="b base">

--- a/app/components/ImportDialog.vue
+++ b/app/components/ImportDialog.vue
@@ -20,7 +20,7 @@ function onClickOutside() {
 <template>
   <ModalPopup
     :model-value="state.isImporting"
-    dialog-class="max-h-80vh! min-h-50vh grid grid-rows-[max-content_1fr_max-content] p0!"
+    dialog-class="max-h-80%! min-h-50% grid grid-rows-[max-content_1fr_max-content] p0!"
     @click-outside="onClickOutside"
   >
     <div p2 text-xl flex="~ gap-2 items-center justify-center" border="b base">

--- a/app/components/SettingsDialog.vue
+++ b/app/components/SettingsDialog.vue
@@ -17,7 +17,7 @@ const { t, locale, locales, setLocale } = useI18n()
   <ModalPopup
     v-model="showSettingsDialog"
     :direction="isMobileScreen ? 'bottom' : 'top'"
-    dialog-class="max-h-80%! of-auto"
+    dialog-class="max-h-80dvh! of-auto"
   >
     <div flex p6 lt-lg="px2">
       <div mxa max-w-150 w-full flex="~ col gap-5 items-center">

--- a/app/components/SettingsDialog.vue
+++ b/app/components/SettingsDialog.vue
@@ -17,7 +17,7 @@ const { t, locale, locales, setLocale } = useI18n()
   <ModalPopup
     v-model="showSettingsDialog"
     :direction="isMobileScreen ? 'bottom' : 'top'"
-    dialog-class="max-h-80vh! of-auto"
+    dialog-class="max-h-80%! of-auto"
   >
     <div flex p6 lt-lg="px2">
       <div mxa max-w-150 w-full flex="~ col gap-5 items-center">

--- a/app/components/SongActions.vue
+++ b/app/components/SongActions.vue
@@ -152,7 +152,7 @@ function shareWithQifi() {
     v-model="showShareQifiCode"
     :direction="isMobileScreen ? 'top' : 'right'"
     :use-v-if="true"
-    :dialog-class="isMobileScreen ? 'max-h-85%! of-auto' : 'max-w-150!'"
+    :dialog-class="isMobileScreen ? 'max-h-85dvh! of-auto' : 'max-w-150!'"
   >
     <QifiCode
       :share-url="shareUrl"

--- a/app/components/SongActions.vue
+++ b/app/components/SongActions.vue
@@ -152,7 +152,7 @@ function shareWithQifi() {
     v-model="showShareQifiCode"
     :direction="isMobileScreen ? 'top' : 'right'"
     :use-v-if="true"
-    :dialog-class="isMobileScreen ? 'max-h-85vh! of-auto' : 'max-w-150!'"
+    :dialog-class="isMobileScreen ? 'max-h-85%! of-auto' : 'max-w-150!'"
   >
     <QifiCode
       :share-url="shareUrl"

--- a/app/components/SongPlay.vue
+++ b/app/components/SongPlay.vue
@@ -154,7 +154,7 @@ onMounted(() => {
         <SettingsFloat mxa lt-lg="hidden" />
       </div>
     </LyricsTrack>
-    <ModalPopup v-model="showInfoModal" dialog-class="max-h-90%! p4">
+    <ModalPopup v-model="showInfoModal" dialog-class="max-h-90dvh! p4">
       <div pb-1 font-jp-serif>
         <p text-1.5em>
           {{ song.title }}

--- a/app/components/SongPlay.vue
+++ b/app/components/SongPlay.vue
@@ -154,7 +154,7 @@ onMounted(() => {
         <SettingsFloat mxa lt-lg="hidden" />
       </div>
     </LyricsTrack>
-    <ModalPopup v-model="showInfoModal" dialog-class="max-h-90vh! p4">
+    <ModalPopup v-model="showInfoModal" dialog-class="max-h-90%! p4">
       <div pb-1 font-jp-serif>
         <p text-1.5em>
           {{ song.title }}

--- a/app/components/WelcomeDialog.vue
+++ b/app/components/WelcomeDialog.vue
@@ -17,8 +17,8 @@ onMounted(() => {
 </script>
 
 <template>
-  <ModalPopup v-model="open" direction="top">
-    <div class="markdown-content mxa max-h-80vh max-w-150 p6">
+  <ModalPopup v-model="open" direction="top" dialog-class="max-h-80%">
+    <div class="markdown-content mxa max-w-150 p6">
       <Welcome />
       <div flex p5>
         <SimpleButton

--- a/app/components/WelcomeDialog.vue
+++ b/app/components/WelcomeDialog.vue
@@ -17,7 +17,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <ModalPopup v-model="open" direction="top" dialog-class="max-h-80dvh">
+  <ModalPopup v-model="open" direction="top" dialog-class="max-h-80dvh!">
     <div class="markdown-content mxa max-w-150 p6">
       <Welcome />
       <div flex p5>

--- a/app/components/WelcomeDialog.vue
+++ b/app/components/WelcomeDialog.vue
@@ -17,7 +17,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <ModalPopup v-model="open" direction="top" dialog-class="max-h-80%">
+  <ModalPopup v-model="open" direction="top" dialog-class="max-h-80dvh">
     <div class="markdown-content mxa max-w-150 p6">
       <Welcome />
       <div flex p5>

--- a/app/components/editors/GPTDialog.vue
+++ b/app/components/editors/GPTDialog.vue
@@ -51,6 +51,6 @@ onMounted(() => {
     <div text-center op50>
       {{ $t('gpt.noteAboutPrompts') }}
     </div>
-    <pre mxa max-h-50vh max-w-200 of-auto rounded-xl bg-hex-888:15 px3 py2 text-sm v-text="gptText" />
+    <pre mxa max-h-50dvh max-w-200 of-auto rounded-xl bg-hex-888:15 px3 py2 text-sm v-text="gptText" />
   </div>
 </template>

--- a/app/components/editors/InsertMultilineLyricsDialog.vue
+++ b/app/components/editors/InsertMultilineLyricsDialog.vue
@@ -16,7 +16,7 @@ function importLyrics() {
 <template>
   <ModalPopup
     v-model="visible"
-    dialog-class="h-60vh! p0! flex justify-center"
+    dialog-class="h-60%! p0! flex justify-center"
     @click-outside="visible = false"
   >
     <div flex="~ col gap-4" h-full max-w-700px w-full p6>

--- a/app/components/editors/InsertMultilineLyricsDialog.vue
+++ b/app/components/editors/InsertMultilineLyricsDialog.vue
@@ -16,7 +16,7 @@ function importLyrics() {
 <template>
   <ModalPopup
     v-model="visible"
-    dialog-class="h-60%! p0! flex justify-center"
+    dialog-class="h-60dvh! p0! flex justify-center"
     @click-outside="visible = false"
   >
     <div flex="~ col gap-4" h-full max-w-700px w-full p6>

--- a/app/components/editors/SongEditor.vue
+++ b/app/components/editors/SongEditor.vue
@@ -429,7 +429,7 @@ onMounted(() => {
         input-class="min-h-400"
       />
 
-      <ModalPopup v-model="showGPTDialog" use-v-if direction="bottom" dialog-class="max-h-80vh">
+      <ModalPopup v-model="showGPTDialog" use-v-if direction="bottom" dialog-class="max-h-80%">
         <GPTDialog :lrc="stateRef.lrc" />
       </ModalPopup>
     </div>

--- a/app/components/editors/SongEditor.vue
+++ b/app/components/editors/SongEditor.vue
@@ -429,7 +429,12 @@ onMounted(() => {
         input-class="min-h-400"
       />
 
-      <ModalPopup v-model="showGPTDialog" use-v-if direction="bottom" dialog-class="max-h-80dvh">
+      <ModalPopup
+        v-model="showGPTDialog"
+        use-v-if
+        direction="bottom"
+        dialog-class="max-h-80dvh!"
+      >
         <GPTDialog :lrc="stateRef.lrc" />
       </ModalPopup>
     </div>

--- a/app/components/editors/SongEditor.vue
+++ b/app/components/editors/SongEditor.vue
@@ -429,7 +429,7 @@ onMounted(() => {
         input-class="min-h-400"
       />
 
-      <ModalPopup v-model="showGPTDialog" use-v-if direction="bottom" dialog-class="max-h-80%">
+      <ModalPopup v-model="showGPTDialog" use-v-if direction="bottom" dialog-class="max-h-80dvh">
         <GPTDialog :lrc="stateRef.lrc" />
       </ModalPopup>
     </div>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -180,7 +180,7 @@ onMounted(() => {
 
     <div ref="searchAnchorEl" mb8 />
 
-    <div flex="~ col gap-8" min-h-100vh p10>
+    <div flex="~ col gap-8" min-h-full p10>
       <SongsGrid v-if="!search.trimEnd() && favorited.length" :link="true" :songs="favorited" show-favorite="hover">
         <template #title>
           <div>{{ $t("actions.favorite") }}</div>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -180,7 +180,7 @@ onMounted(() => {
 
     <div ref="searchAnchorEl" mb8 />
 
-    <div flex="~ col gap-8" min-h-full p10>
+    <div flex="~ col gap-8" min-h-100dvh p10>
       <SongsGrid v-if="!search.trimEnd() && favorited.length" :link="true" :songs="favorited" show-favorite="hover">
         <template #title>
           <div>{{ $t("actions.favorite") }}</div>

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -52,6 +52,16 @@ export default defineConfig({
       primary: '#0a9cae',
     },
   },
+  rules: [
+    [/^h-(\d+)dvh$/, ([_, d]) => [
+      ['height', `${d}vh`],
+      ['height', `${d}dvh`],
+    ]],
+    [/^max-h-(\d+)dvh$/, ([_, d]) => [
+      ['max-height', `${d}vh`],
+      ['max-height', `${d}dvh`],
+    ]],
+  ],
   presets: [
     presetUno(),
     presetAttributify(),


### PR DESCRIPTION
For mobile device, where the address bar of the browser may likely to be hiding during browsing the page, which makes `vh` not accurate when it is hiding.

Using `dvh` or `%` solves this problem, while for full screen element, I believe that they are the same with `%` more compatible
> `dvh` coverage is ~92% now
> https://caniuse.com/viewport-unit-variants

Or do you think it is safer to use `dvh` instead?