### PR TITLE
fix: use Dropdown instead of Menu on Mobile

### DIFF
--- a/app/components/SettingsDialog.vue
+++ b/app/components/SettingsDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { MaruSongDataParsed } from '@marure/schema'
-import { Menu } from 'floating-vue'
+import { Dropdown, Menu } from 'floating-vue'
 import { isMobileScreen } from '~/state/breakpoints'
 import { showSettingsDialog, showShortcutDialog } from '~/state/models'
 
@@ -91,7 +91,9 @@ const { t, locale, locales, setLocale } = useI18n()
           <DarkToggle
             type="button"
           />
-          <Menu>
+          <component
+            :is="isMobileScreen ? Dropdown : Menu"
+          >
             <SimpleButton icon="i-uil-english-to-chinese" :title="t('actions.languages')" />
             <template #popper>
               <div p2 flex="~ col gap-1">
@@ -103,7 +105,7 @@ const { t, locale, locales, setLocale } = useI18n()
                 />
               </div>
             </template>
-          </Menu>
+          </component>
           <ActionButton
             icon="i-uil-keyboard-alt"
             type="button"

--- a/app/components/atomic/I18nSelector.vue
+++ b/app/components/atomic/I18nSelector.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
-import { Menu } from 'floating-vue'
+import { Dropdown, Menu } from 'floating-vue'
+import { isMobileScreen } from '~/state/breakpoints'
 
 const { locale, locales, setLocale } = useI18n()
 </script>
 
 <template>
-  <Menu placement="top">
+  <component
+    :is="isMobileScreen ? Dropdown : Menu"
+    placement="top"
+  >
     <IconButton icon="i-uil-english-to-chinese" />
     <template #popper>
       <div p2 flex="~ col gap-1">
@@ -17,5 +21,5 @@ const { locale, locales, setLocale } = useI18n()
         />
       </div>
     </template>
-  </Menu>
+  </component>
 </template>


### PR DESCRIPTION
This PR improves the language-switching experience on mobile. It uses `Menu` by default, but switches to `Dropdown` only on mobile.

Before:

https://github.com/user-attachments/assets/023ed84b-62f4-4ee9-927e-22bdf58f7b4f

https://github.com/user-attachments/assets/86210e65-ec5d-484b-ba5d-a8ab2d9deadb

After:

https://github.com/user-attachments/assets/d073b13c-a833-4cb3-a5b4-f2a844c37f2d


https://github.com/user-attachments/assets/97d628f9-2aea-4986-8c23-1c924f3bda80
